### PR TITLE
chore: ensure locale is set to UTF-8 in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y openssl='3.*
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+ENV LANG C.utf8
+
 ARG MIX_ENV=prod
 ENV MIX_ENV=${MIX_ENV}
 


### PR DESCRIPTION
fix this warning

> warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell) or set the ELIXIR_ERL_OPTIONS="+fnu" environment variable